### PR TITLE
use occam serve matcher

### DIFF
--- a/integration/rails_5.0_test.go
+++ b/integration/rails_5.0_test.go
@@ -2,7 +2,6 @@ package integration_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -100,13 +99,7 @@ func testRails50(t *testing.T, context spec.G, it spec.S) {
 			path, _ = selection.Attr("src")
 		})
 
-		response, err = http.Get(fmt.Sprintf("http://localhost:%s%s", container.HostPort("8080"), path))
-		Expect(err).NotTo(HaveOccurred())
-		defer response.Body.Close()
-
-		content, err := ioutil.ReadAll(response.Body)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(string(content)).To(ContainSubstring("Hello from Javascript!"))
+		Eventually(container).Should(Serve(ContainSubstring("Hello from Javascript!")).OnPort(8080).WithEndpoint(path))
 
 		Expect(logs).To(ContainLines(
 			MatchRegexp(fmt.Sprintf(`%s \d+\.\d+\.\d+`, settings.Buildpack.Name)),

--- a/integration/rails_6.0_test.go
+++ b/integration/rails_6.0_test.go
@@ -2,7 +2,6 @@ package integration_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -101,13 +100,7 @@ func testRails60(t *testing.T, context spec.G, it spec.S) {
 			path, _ = selection.Attr("src")
 		})
 
-		response, err = http.Get(fmt.Sprintf("http://localhost:%s%s", container.HostPort("8080"), path))
-		Expect(err).NotTo(HaveOccurred())
-		defer response.Body.Close()
-
-		content, err := ioutil.ReadAll(response.Body)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(string(content)).To(ContainSubstring("Hello from Javascript!"))
+		Eventually(container).Should(Serve(ContainSubstring("Hello from Javascript!")).OnPort(8080).WithEndpoint(path))
 
 		Expect(logs).To(ContainLines(
 			MatchRegexp(fmt.Sprintf(`%s \d+\.\d+\.\d+`, settings.Buildpack.Name)),


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

Updates integration tests to use the occam serve matcher.

## Use Cases
<!-- An explanation of the use cases your change enables -->

This ensures the test suite use the most up to date features of occam.

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have added an integration test, if necessary.