### PR TITLE
Includes public/packs as a directory managed in a layer

### DIFF
--- a/build_test.go
+++ b/build_test.go
@@ -53,12 +53,6 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 		err = os.MkdirAll(filepath.Join(workingDir, "app", "assets"), os.ModePerm)
 		Expect(err).NotTo(HaveOccurred())
 
-		err = os.MkdirAll(filepath.Join(workingDir, "public", "assets"), os.ModePerm)
-		Expect(err).NotTo(HaveOccurred())
-
-		err = os.MkdirAll(filepath.Join(workingDir, "tmp", "assets", "cache"), os.ModePerm)
-		Expect(err).NotTo(HaveOccurred())
-
 		buildProcess = &fakes.BuildProcess{}
 
 		buffer = bytes.NewBuffer(nil)

--- a/directory_setup.go
+++ b/directory_setup.go
@@ -14,15 +14,20 @@ func NewDirectorySetup() DirectorySetup {
 	return DirectorySetup{}
 }
 
-// ResetLocal deletes public/assets and tmp/cache/assets directories. These
-// directories will be replaced by links to directories internal to the
-// "assets" layer that is created by this buildpack.
+// ResetLocal deletes public/assets, public/packs, and tmp/cache/assets
+// directories. These directories will be replaced by links to directories
+// internal to the "assets" layer that is created by this buildpack.
 //
 // Additionally, ResetLocal ensures that the working directory at least
 // contains a public and tmp/cache directory so that these links have a
 // location to be placed into.
 func (DirectorySetup) ResetLocal(workingDir string) error {
 	err := os.RemoveAll(filepath.Join(workingDir, "public", "assets"))
+	if err != nil {
+		return err
+	}
+
+	err = os.RemoveAll(filepath.Join(workingDir, "public", "packs"))
 	if err != nil {
 		return err
 	}
@@ -45,11 +50,16 @@ func (DirectorySetup) ResetLocal(workingDir string) error {
 	return nil
 }
 
-// ResetLayer ensures that the "assets" layer contains public-assets and
-// tmp-cache-assets directories. These directories will hold the results of
-// running the "rails assets:precompile" build process.
+// ResetLayer ensures that the "assets" layer contains public-assets,
+// public-packs, and tmp-cache-assets directories. These directories will hold
+// the results of running the "rails assets:precompile" build process.
 func (DirectorySetup) ResetLayer(layerPath string) error {
 	err := os.MkdirAll(filepath.Join(layerPath, "public-assets"), os.ModePerm)
+	if err != nil {
+		return err
+	}
+
+	err = os.MkdirAll(filepath.Join(layerPath, "public-packs"), os.ModePerm)
 	if err != nil {
 		return err
 	}
@@ -69,6 +79,11 @@ func (DirectorySetup) ResetLayer(layerPath string) error {
 // cached and reused on subsequent builds.
 func (DirectorySetup) Link(layerPath, workingDir string) error {
 	err := os.Symlink(filepath.Join(layerPath, "public-assets"), filepath.Join(workingDir, "public", "assets"))
+	if err != nil {
+		return err
+	}
+
+	err = os.Symlink(filepath.Join(layerPath, "public-packs"), filepath.Join(workingDir, "public", "packs"))
 	if err != nil {
 		return err
 	}

--- a/directory_setup_test.go
+++ b/directory_setup_test.go
@@ -6,9 +6,10 @@ import (
 	"path/filepath"
 	"testing"
 
-	. "github.com/onsi/gomega"
 	railsassets "github.com/paketo-buildpacks/rails-assets"
 	"github.com/sclevine/spec"
+
+	. "github.com/onsi/gomega"
 )
 
 func testDirectorySetup(t *testing.T, context spec.G, it spec.S) {
@@ -37,28 +38,32 @@ func testDirectorySetup(t *testing.T, context spec.G, it spec.S) {
 	})
 
 	context("ResetLocal", func() {
+		it.Before(func() {
+			Expect(os.MkdirAll(filepath.Join(workingDir, "public", "assets"), os.ModePerm)).To(Succeed())
+			Expect(os.MkdirAll(filepath.Join(workingDir, "public", "packs"), os.ModePerm)).To(Succeed())
+			Expect(os.MkdirAll(filepath.Join(workingDir, "tmp", "cache", "assets"), os.ModePerm)).To(Succeed())
+		})
+
 		it("recreates directories", func() {
 			err := setup.ResetLocal(workingDir)
 			Expect(err).NotTo(HaveOccurred())
 
-			_, err = os.Stat(filepath.Join(workingDir, "public"))
-			Expect(err).NotTo(HaveOccurred())
+			Expect(filepath.Join(workingDir, "public")).To(BeADirectory())
+			Expect(filepath.Join(workingDir, "tmp", "cache")).To(BeADirectory())
 
-			_, err = os.Stat(filepath.Join(workingDir, "tmp", "cache"))
-			Expect(err).NotTo(HaveOccurred())
+			Expect(filepath.Join(workingDir, "public", "assets")).NotTo(BeADirectory())
+			Expect(filepath.Join(workingDir, "public", "packs")).NotTo(BeADirectory())
+			Expect(filepath.Join(workingDir, "tmp", "cache", "assets")).NotTo(BeADirectory())
 		})
 	})
 
 	context("ResetLayer", func() {
 		it("creates the directories", func() {
-			err := setup.ResetLayer(layerPath)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(setup.ResetLayer(layerPath)).To(Succeed())
 
-			_, err = os.Stat(filepath.Join(layerPath, "tmp-cache-assets"))
-			Expect(err).NotTo(HaveOccurred())
-
-			_, err = os.Stat(filepath.Join(layerPath, "public-assets"))
-			Expect(err).NotTo(HaveOccurred())
+			Expect(filepath.Join(layerPath, "tmp-cache-assets")).To(BeADirectory())
+			Expect(filepath.Join(layerPath, "public-assets")).To(BeADirectory())
+			Expect(filepath.Join(layerPath, "public-packs")).To(BeADirectory())
 		})
 	})
 
@@ -82,6 +87,10 @@ func testDirectorySetup(t *testing.T, context spec.G, it spec.S) {
 			link, err = os.Readlink(filepath.Join(workingDir, "public", "assets"))
 			Expect(err).NotTo(HaveOccurred())
 			Expect(link).To(Equal(filepath.Join(layerPath, "public-assets")))
+
+			link, err = os.Readlink(filepath.Join(workingDir, "public", "packs"))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(link).To(Equal(filepath.Join(layerPath, "public-packs")))
 		})
 	})
 }

--- a/integration/rails_6.0_test.go
+++ b/integration/rails_6.0_test.go
@@ -130,11 +130,22 @@ func testRails60(t *testing.T, context spec.G, it spec.S) {
 			Expect(firstImage.Buildpacks[6].Layers).To(HaveKey("assets"))
 
 			container, err := settings.Docker.Container.Run.
-				WithCommand(fmt.Sprintf("ls -alR /layers/%s/assets/public/assets", strings.ReplaceAll(settings.Buildpack.ID, "/", "_"))).
+				WithEnv(map[string]string{
+					"PORT":            "8080",
+					"SECRET_KEY_BASE": "some-secret",
+				}).
+				WithPublish("8080").
+				WithPublishAll().
 				Execute(firstImage.ID)
 			Expect(err).NotTo(HaveOccurred())
 
 			containerIDs[container.ID] = struct{}{}
+
+			Eventually(container).Should(BeAvailable())
+
+			response, err := http.Get(fmt.Sprintf("http://localhost:%s", container.HostPort("8080")))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(response.StatusCode).To(Equal(http.StatusOK))
 
 			secondImage, secondLogs, err := build.Execute(name, source)
 			Expect(err).NotTo(HaveOccurred(), secondLogs.String)
@@ -146,11 +157,22 @@ func testRails60(t *testing.T, context spec.G, it spec.S) {
 			Expect(secondImage.Buildpacks[6].Layers).To(HaveKey("assets"))
 
 			container, err = settings.Docker.Container.Run.
-				WithCommand(fmt.Sprintf("ls -alR /layers/%s/assets/public/assets", strings.ReplaceAll(settings.Buildpack.ID, "/", "_"))).
+				WithEnv(map[string]string{
+					"PORT":            "8080",
+					"SECRET_KEY_BASE": "some-secret",
+				}).
+				WithPublish("8080").
+				WithPublishAll().
 				Execute(secondImage.ID)
 			Expect(err).NotTo(HaveOccurred())
 
 			containerIDs[container.ID] = struct{}{}
+
+			Eventually(container).Should(BeAvailable())
+
+			response, err = http.Get(fmt.Sprintf("http://localhost:%s", container.HostPort("8080")))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(response.StatusCode).To(Equal(http.StatusOK))
 
 			Expect(secondImage.Buildpacks[6].Layers["assets"].Metadata["built_at"]).To(Equal(firstImage.Buildpacks[6].Layers["assets"].Metadata["built_at"]))
 			Expect(secondImage.Buildpacks[6].Layers["assets"].Metadata["cache_sha"]).To(Equal(firstImage.Buildpacks[6].Layers["assets"].Metadata["cache_sha"]))
@@ -180,11 +202,22 @@ func testRails60(t *testing.T, context spec.G, it spec.S) {
 				Expect(firstImage.Buildpacks[6].Layers).To(HaveKey("assets"))
 
 				container, err := settings.Docker.Container.Run.
-					WithCommand(fmt.Sprintf("ls -alR /layers/%s/assets/public/assets", strings.ReplaceAll(settings.Buildpack.ID, "/", "_"))).
+					WithEnv(map[string]string{
+						"PORT":            "8080",
+						"SECRET_KEY_BASE": "some-secret",
+					}).
+					WithPublish("8080").
+					WithPublishAll().
 					Execute(firstImage.ID)
 				Expect(err).NotTo(HaveOccurred())
 
 				containerIDs[container.ID] = struct{}{}
+
+				Eventually(container).Should(BeAvailable())
+
+				response, err := http.Get(fmt.Sprintf("http://localhost:%s", container.HostPort("8080")))
+				Expect(err).NotTo(HaveOccurred())
+				Expect(response.StatusCode).To(Equal(http.StatusOK))
 
 				file, err := os.OpenFile(filepath.Join(source, "app", "javascript", "packs", "application.js"), os.O_APPEND|os.O_RDWR, 0600)
 				Expect(err).NotTo(HaveOccurred())
@@ -204,11 +237,22 @@ func testRails60(t *testing.T, context spec.G, it spec.S) {
 				Expect(secondImage.Buildpacks[6].Layers).To(HaveKey("assets"))
 
 				container, err = settings.Docker.Container.Run.
-					WithCommand(fmt.Sprintf("ls -alR /layers/%s/assets/public/assets", strings.ReplaceAll(settings.Buildpack.ID, "/", "_"))).
+					WithEnv(map[string]string{
+						"PORT":            "8080",
+						"SECRET_KEY_BASE": "some-secret",
+					}).
+					WithPublish("8080").
+					WithPublishAll().
 					Execute(secondImage.ID)
 				Expect(err).NotTo(HaveOccurred())
 
 				containerIDs[container.ID] = struct{}{}
+
+				Eventually(container).Should(BeAvailable())
+
+				response, err = http.Get(fmt.Sprintf("http://localhost:%s", container.HostPort("8080")))
+				Expect(err).NotTo(HaveOccurred())
+				Expect(response.StatusCode).To(Equal(http.StatusOK))
 
 				Expect(secondImage.Buildpacks[6].Layers["assets"].Metadata["built_at"]).NotTo(Equal(firstImage.Buildpacks[6].Layers["assets"].Metadata["built_at"]))
 				Expect(secondImage.Buildpacks[6].Layers["assets"].Metadata["cache_sha"]).NotTo(Equal(firstImage.Buildpacks[6].Layers["assets"].Metadata["cache_sha"]))


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
Rails 6.0 applications will also populate the `public/packs` directory during the asset precompilation process. We need to store the contents of this directory in a layer so that we can bring it back when we skip the build process.

## Use Cases
<!-- An explanation of the use cases your change enables -->
Resolves #35.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
