### PR TITLE
Add  "-e production" to asset precompilation command

### DIFF
--- a/precompile_process.go
+++ b/precompile_process.go
@@ -38,7 +38,7 @@ func (p PrecompileProcess) Execute(workingDir string) error {
 	os.Setenv("RAILS_ENV", "production")
 
 	buffer := bytes.NewBuffer(nil)
-	args := []string{"exec", "rails", "assets:precompile", "assets:clean"}
+	args := []string{"exec", "rails", "assets:precompile", "assets:clean", "-e production"}
 
 	p.logger.Subprocess("Running 'bundle %s'", strings.Join(args, " "))
 	err := p.executable.Execute(pexec.Execution{


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

Attempting to fix an issue in which `rails` errors out with:
```
failed to execute bundle exec output:
rails aborted!
LoadError: cannot load such file -- uglifier
```
This is related to the fact that the bundle-install buildpack [does not install `development` gems now](https://github.com/paketo-buildpacks/bundle-install/pull/160), but rails appears to be looking for those gems.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
