### PR TITLE
Bumps buildpack API to 0.6

### DIFF
--- a/build.go
+++ b/build.go
@@ -105,6 +105,7 @@ func Build(
 			logger.Process("Reusing cached layer %s", assetsLayer.Path)
 			logger.Break()
 
+			assetsLayer.Launch = true
 			err = environmentSetup.Link(assetsLayer.Path, context.WorkingDir)
 			if err != nil {
 				return packit.BuildResult{}, err

--- a/build_test.go
+++ b/build_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -41,13 +40,13 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 
 	it.Before(func() {
 		var err error
-		layersDir, err = ioutil.TempDir("", "layers")
+		layersDir, err = os.MkdirTemp("", "layers")
 		Expect(err).NotTo(HaveOccurred())
 
-		cnbDir, err = ioutil.TempDir("", "cnb")
+		cnbDir, err = os.MkdirTemp("", "cnb")
 		Expect(err).NotTo(HaveOccurred())
 
-		workingDir, err = ioutil.TempDir("", "working-dir")
+		workingDir, err = os.MkdirTemp("", "working-dir")
 		Expect(err).NotTo(HaveOccurred())
 
 		err = os.MkdirAll(filepath.Join(workingDir, "app", "assets"), os.ModePerm)
@@ -122,9 +121,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 
 	context("when checksum matches", func() {
 		it.Before(func() {
-			err := ioutil.WriteFile(filepath.Join(layersDir, fmt.Sprintf("%s.toml", railsassets.LayerNameAssets)), []byte(fmt.Sprintf(`
-launch = true
-
+			err := os.WriteFile(filepath.Join(layersDir, fmt.Sprintf("%s.toml", railsassets.LayerNameAssets)), []byte(fmt.Sprintf(`
 [metadata]
 	cache_sha = "some-calculator-sha"
 	built_at = "%s"
@@ -133,10 +130,10 @@ launch = true
 
 			Expect(os.MkdirAll(filepath.Join(layersDir, "assets", "env.launch"), os.ModePerm)).To(Succeed())
 
-			err = ioutil.WriteFile(filepath.Join(layersDir, "assets", "env.launch", "RAILS_ENV.default"), []byte("production"), 0600)
+			err = os.WriteFile(filepath.Join(layersDir, "assets", "env.launch", "RAILS_ENV.default"), []byte("production"), 0600)
 			Expect(err).NotTo(HaveOccurred())
 
-			err = ioutil.WriteFile(filepath.Join(layersDir, "assets", "env.launch", "RAILS_SERVE_STATIC_FILES.default"), []byte("true"), 0600)
+			err = os.WriteFile(filepath.Join(layersDir, "assets", "env.launch", "RAILS_SERVE_STATIC_FILES.default"), []byte("true"), 0600)
 			Expect(err).NotTo(HaveOccurred())
 
 			calculator.SumCall.Returns.String = "some-calculator-sha"

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -1,4 +1,4 @@
-api = "0.5"
+api = "0.6"
 
 [buildpack]
   homepage = "https://github.com/paketo-buildpacks/rails-assets"

--- a/detect_test.go
+++ b/detect_test.go
@@ -6,8 +6,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"io/ioutil"
-
 	"github.com/paketo-buildpacks/packit"
 	railsassets "github.com/paketo-buildpacks/rails-assets"
 	"github.com/paketo-buildpacks/rails-assets/fakes"
@@ -27,10 +25,10 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 
 	it.Before(func() {
 		var err error
-		workingDir, err = ioutil.TempDir("", "working-dir")
+		workingDir, err = os.MkdirTemp("", "working-dir")
 		Expect(err).NotTo(HaveOccurred())
 
-		err = ioutil.WriteFile(filepath.Join(workingDir, "Gemfile"), []byte{}, 0600)
+		err = os.WriteFile(filepath.Join(workingDir, "Gemfile"), []byte{}, 0600)
 		Expect(err).NotTo(HaveOccurred())
 
 		gemfileParser = &fakes.Parser{}
@@ -70,7 +68,7 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 
 			context("when the working directory contains a yarn.lock file", func() {
 				it.Before(func() {
-					Expect(ioutil.WriteFile(filepath.Join(workingDir, "yarn.lock"), nil, 0600)).To(Succeed())
+					Expect(os.WriteFile(filepath.Join(workingDir, "yarn.lock"), nil, 0600)).To(Succeed())
 				})
 
 				it("detects with node_modules", func() {

--- a/directory_setup_test.go
+++ b/directory_setup_test.go
@@ -1,7 +1,6 @@
 package railsassets_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -23,10 +22,10 @@ func testDirectorySetup(t *testing.T, context spec.G, it spec.S) {
 
 	it.Before(func() {
 		var err error
-		layerPath, err = ioutil.TempDir("", "layers")
+		layerPath, err = os.MkdirTemp("", "layers")
 		Expect(err).NotTo(HaveOccurred())
 
-		workingDir, err = ioutil.TempDir("", "working-dir")
+		workingDir, err = os.MkdirTemp("", "working-dir")
 		Expect(err).NotTo(HaveOccurred())
 
 		setup = railsassets.NewDirectorySetup()

--- a/gemfile_parser_test.go
+++ b/gemfile_parser_test.go
@@ -1,7 +1,6 @@
 package railsassets_test
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -20,7 +19,7 @@ func testGemfileParser(t *testing.T, context spec.G, it spec.S) {
 	)
 
 	it.Before(func() {
-		file, err := ioutil.TempFile("", "Gemfile")
+		file, err := os.CreateTemp("", "Gemfile")
 		Expect(err).NotTo(HaveOccurred())
 		defer file.Close()
 
@@ -36,29 +35,24 @@ func testGemfileParser(t *testing.T, context spec.G, it spec.S) {
 	context("Parse", func() {
 		context("when using rails", func() {
 			it("parses correctly", func() {
-				const GEMFILE_CONTENTS = `
-source 'https://rubygems.org' do
+				Expect(os.WriteFile(path, []byte(`source 'https://rubygems.org' do
 	gem 'rails'
 end
-`
-
-				Expect(ioutil.WriteFile(path, []byte(GEMFILE_CONTENTS), 0644)).To(Succeed())
+`), 0600)).To(Succeed())
 
 				hasRails, err := parser.Parse(path)
 				Expect(err).NotTo(HaveOccurred())
-				Expect(hasRails).To(Equal(true))
+				Expect(hasRails).To(BeTrue())
 			})
 		})
 
 		context("when not using rails", func() {
 			it("parses correctly", func() {
-				const GEMFILE_CONTENTS = `source 'https://rubygems.org'`
-
-				Expect(ioutil.WriteFile(path, []byte(GEMFILE_CONTENTS), 0644)).To(Succeed())
+				Expect(os.WriteFile(path, []byte(`source 'https://rubygems.org'`), 0600)).To(Succeed())
 
 				hasRails, err := parser.Parse(path)
 				Expect(err).NotTo(HaveOccurred())
-				Expect(hasRails).To(Equal(false))
+				Expect(hasRails).To(BeFalse())
 			})
 		})
 
@@ -70,7 +64,7 @@ end
 			it("returns all false", func() {
 				hasRails, err := parser.Parse(path)
 				Expect(err).NotTo(HaveOccurred())
-				Expect(hasRails).To(Equal(false))
+				Expect(hasRails).To(BeFalse())
 			})
 		})
 

--- a/precompile_process_test.go
+++ b/precompile_process_test.go
@@ -3,7 +3,6 @@ package railsassets_test
 import (
 	"bytes"
 	"errors"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -31,7 +30,7 @@ func testPrecompileProcess(t *testing.T, context spec.G, it spec.S) {
 
 		it.Before(func() {
 			var err error
-			workingDir, err = ioutil.TempDir("", "working-dir")
+			workingDir, err = os.MkdirTemp("", "working-dir")
 			Expect(err).NotTo(HaveOccurred())
 
 			executions = []pexec.Execution{}


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
All buildpacks that have upgraded to the latest version of `packit` should be able to run with buildpack API 0.6.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
