### PR TITLE
Configure Rails to log to stdout instead of the filesystem

### DIFF
--- a/build.go
+++ b/build.go
@@ -61,6 +61,7 @@ type EnvironmentSetup interface {
 //      * RAILS_SERVE_STATIC_FILES : configure Rails to serve static files
 //      itself instead of expecting that a file server like NGINX will serve
 //      them
+//      * RAILS_LOG_TO_STDOUT=true : Rails will log to stdout
 //   7. Attach build metadata onto the new "assets" layer so that it can be
 //   referenced in future builds.
 func Build(
@@ -148,6 +149,7 @@ func Build(
 		assetsLayer.Launch = true
 		assetsLayer.LaunchEnv.Default("RAILS_ENV", "production")
 		assetsLayer.LaunchEnv.Default("RAILS_SERVE_STATIC_FILES", "true")
+		assetsLayer.LaunchEnv.Default("RAILS_LOG_TO_STDOUT", "true")
 		logger.EnvironmentVariables(assetsLayer)
 
 		assetsLayer.Metadata = map[string]interface{}{

--- a/build_test.go
+++ b/build_test.go
@@ -94,6 +94,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 					LaunchEnv: packit.Environment{
 						"RAILS_ENV.default":                "production",
 						"RAILS_SERVE_STATIC_FILES.default": "true",
+						"RAILS_LOG_TO_STDOUT.default":      "true",
 					},
 					ProcessLaunchEnv: map[string]packit.Environment{},
 					Metadata: map[string]interface{}{

--- a/integration/rails_5.0_test.go
+++ b/integration/rails_5.0_test.go
@@ -121,7 +121,12 @@ func testRails50(t *testing.T, context spec.G, it spec.S) {
 			"",
 			"  Configuring launch environment",
 			`    RAILS_ENV                -> "production"`,
+			`    RAILS_LOG_TO_STDOUT      -> "true"`,
 			`    RAILS_SERVE_STATIC_FILES -> "true"`,
 		))
+
+		logs, err = settings.Docker.Container.Logs.Execute(container.ID)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(logs).To(ContainLines(ContainSubstring("Processing by WelcomeController#index")))
 	})
 }

--- a/integration/rails_6.0_test.go
+++ b/integration/rails_6.0_test.go
@@ -111,7 +111,12 @@ func testRails60(t *testing.T, context spec.G, it spec.S) {
 			"",
 			"  Configuring launch environment",
 			`    RAILS_ENV                -> "production"`,
+			`    RAILS_LOG_TO_STDOUT      -> "true"`,
 			`    RAILS_SERVE_STATIC_FILES -> "true"`,
 		))
+
+		logs, err = settings.Docker.Container.Logs.Execute(container.ID)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(logs).To(ContainLines(ContainSubstring("Processing by WelcomeController#index")))
 	})
 }

--- a/integration/reuse_layer_rebuild_test.go
+++ b/integration/reuse_layer_rebuild_test.go
@@ -111,6 +111,7 @@ func testReusingLayerRebuild(t *testing.T, context spec.G, it spec.S) {
 			Expect(logs).To(ContainLines(
 				"  Configuring launch environment",
 				`    RAILS_ENV                -> "production"`,
+				`    RAILS_LOG_TO_STDOUT      -> "true"`,
 				`    RAILS_SERVE_STATIC_FILES -> "true"`,
 			))
 
@@ -251,6 +252,7 @@ func testReusingLayerRebuild(t *testing.T, context spec.G, it spec.S) {
 			Expect(logs).To(ContainLines(
 				"  Configuring launch environment",
 				`    RAILS_ENV                -> "production"`,
+				`    RAILS_LOG_TO_STDOUT      -> "true"`,
 				`    RAILS_SERVE_STATIC_FILES -> "true"`,
 			))
 
@@ -306,6 +308,7 @@ func testReusingLayerRebuild(t *testing.T, context spec.G, it spec.S) {
 			Expect(logs).To(ContainLines(
 				"  Configuring launch environment",
 				`    RAILS_ENV                -> "production"`,
+				`    RAILS_LOG_TO_STDOUT      -> "true"`,
 				`    RAILS_SERVE_STATIC_FILES -> "true"`,
 			))
 

--- a/integration/testdata/6.0/config/puma.rb
+++ b/integration/testdata/6.0/config/puma.rb
@@ -17,7 +17,7 @@ port        ENV.fetch("PORT") { 3000 }
 environment ENV.fetch("RAILS_ENV") { "development" }
 
 # Specifies the `pidfile` that Puma will use.
-pidfile ENV.fetch("PIDFILE") { "tmp/pids/server.pid" }
+pidfile ENV.fetch("PIDFILE") { "/tmp/pumd.pid" }
 
 # Specifies the number of `workers` to boot in clustered mode.
 # Workers are forked web server processes. If using threads and workers together


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
Sets the `RAILS_LOG_TO_STDOUT` variable to configure Rails to send its logs to stdout.

## Use Cases
<!-- An explanation of the use cases your change enables -->
Resolves https://github.com/paketo-buildpacks/ruby/issues/567

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
