### PR TITLE
Implement RFC 0050: Rename Buildpack

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -5,7 +5,7 @@ api = "0.7"
   homepage = "https://github.com/paketo-buildpacks/rails-assets"
   id = "paketo-buildpacks/rails-assets"
   keywords = ["ruby", "rails", "assets"]
-  name = "Paketo Rails Assets Buildpack"
+  name = "Paketo Buildpack for Rails Assets"
 
   [[buildpack.licenses]]
     type = "Apache-2.0"


### PR DESCRIPTION
Renames 'Paketo Rails Assets Buildpack' to 'Paketo Buildpack for Rails Assets'.

Implements RFC 0050, https://github.com/paketo-buildpacks/rfcs/issues/233, for this buildpack.

Signed-off-by: Daniel Mikusa <dmikusa@vmware.com>
