### PR TITLE
Set a dummy value for SECRET_KEY_BASE when precompiling

### DIFF
--- a/integration/rails_7.0_test.go
+++ b/integration/rails_7.0_test.go
@@ -64,9 +64,6 @@ func testRails70(t *testing.T, context spec.G, it spec.S) {
 		image, logs, err := settings.Pack.WithVerbose().Build.
 			WithBuildpacks(buildpacks...).
 			WithPullPolicy("never").
-			WithEnv(map[string]string{
-				"SECRET_KEY_BASE": "some-secret",
-			}).
 			Execute(name, source)
 		Expect(err).NotTo(HaveOccurred(), logs.String())
 

--- a/precompile_process.go
+++ b/precompile_process.go
@@ -35,8 +35,6 @@ func NewPrecompileProcess(executable Executable, logger scribe.Emitter) Precompi
 // process. If the process fails, the error message will include the entire
 // output of the child process.
 func (p PrecompileProcess) Execute(workingDir string) error {
-	os.Setenv("RAILS_ENV", "production")
-
 	buffer := bytes.NewBuffer(nil)
 	args := []string{"exec", "rails", "assets:precompile", "assets:clean"}
 
@@ -45,6 +43,7 @@ func (p PrecompileProcess) Execute(workingDir string) error {
 		Args:   args,
 		Stdout: p.logger.ActionWriter,
 		Stderr: p.logger.ActionWriter,
+		Env:    append(os.Environ(), "RAILS_ENV=production", "SECRET_KEY_BASE=dummy"),
 	})
 	if err != nil {
 		return fmt.Errorf("failed to execute bundle exec output:\n%s\nerror: %s", buffer.String(), err)

--- a/precompile_process_test.go
+++ b/precompile_process_test.go
@@ -21,7 +21,6 @@ func testPrecompileProcess(t *testing.T, context spec.G, it spec.S) {
 	context("Execute", func() {
 		var (
 			workingDir string
-			path       string
 			executions []pexec.Execution
 			executable *fakes.Executable
 
@@ -41,17 +40,12 @@ func testPrecompileProcess(t *testing.T, context spec.G, it spec.S) {
 				return nil
 			}
 
-			path = os.Getenv("PATH")
-			os.Setenv("PATH", "/some/bin")
-
 			logger := scribe.NewEmitter(bytes.NewBuffer(nil))
 
 			precompileProcess = railsassets.NewPrecompileProcess(executable, logger)
 		})
 
 		it.After(func() {
-			os.Setenv("PATH", path)
-
 			Expect(os.RemoveAll(workingDir)).To(Succeed())
 		})
 
@@ -61,6 +55,8 @@ func testPrecompileProcess(t *testing.T, context spec.G, it spec.S) {
 
 			Expect(executions).To(HaveLen(1))
 			Expect(executions[0].Args).To(Equal([]string{"exec", "rails", "assets:precompile", "assets:clean"}))
+			Expect(executions[0].Env).To(ContainElement("RAILS_ENV=production"))
+			Expect(executions[0].Env).To(ContainElement("SECRET_KEY_BASE=dummy"))
 		})
 
 		context("failure cases", func() {


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
For Rails 7 apps, you need to set the SECRET_KEY_BASE value in order to run the precompile task. This addition will enable users to omit this environment variable when they run their build.

In Rails 7.1, once is it released, we can use `SECRET_KEY_BASE_DUMMY=1`.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
