### PR TITLE
feat: respect existing RAILS_ENV and SECRET_KEY_BASE

### DIFF
--- a/precompile_process.go
+++ b/precompile_process.go
@@ -43,11 +43,35 @@ func (p PrecompileProcess) Execute(workingDir string) error {
 		Args:   args,
 		Stdout: p.logger.ActionWriter,
 		Stderr: p.logger.ActionWriter,
-		Env:    append(os.Environ(), "RAILS_ENV=production", "SECRET_KEY_BASE=dummy"),
+		Env:    processPrecompileEnv(os.Environ()),
 	})
 	if err != nil {
 		return fmt.Errorf("failed to execute bundle exec output:\n%s\nerror: %s", buffer.String(), err)
 	}
 
 	return nil
+}
+
+func processPrecompileEnv(env []string) []string {
+	hasRailsEnv := false
+	hasSecretKeyBase := false
+	for _, pair := range env {
+		if strings.HasPrefix(pair, "RAILS_ENV=") {
+			hasRailsEnv = true
+		}
+
+		if strings.HasPrefix(pair, "SECRET_KEY_BASE=") {
+			hasSecretKeyBase = true
+		}
+	}
+
+	if !hasRailsEnv {
+		env = append(env, "RAILS_ENV=production")
+	}
+
+	if !hasSecretKeyBase {
+		env = append(env, "SECRET_KEY_BASE=dummy")
+	}
+
+	return env
 }

--- a/precompile_process_test.go
+++ b/precompile_process_test.go
@@ -75,9 +75,16 @@ func testPrecompileProcess(t *testing.T, context spec.G, it spec.S) {
 				Expect(executions[0].Env).To(ContainElement("RAILS_ENV=staging"))
 				Expect(executions[0].Env).To(ContainElement("SECRET_KEY_BASE=dummy"))
 			})
+		})
 
+	        context("when a user sets their own SECRET_KEY_BASE", func() {
+			it.Before(func() {
+				Expect(os.Setenv("SECRET_KEY_BASE", "dummy2")).To(Succeed())
+			})
+			it.After(func() {
+				Expect(os.Unsetenv("SECRET_KEY_BASE")).To(Succeed())
+			})
 			it("runs the bundle exec assets:precompile process while respecting SECRET_KEY_BASE", func() {
-				os.Setenv("SECRET_KEY_BASE", "dummy2")
 				err := precompileProcess.Execute(workingDir)
 				Expect(err).NotTo(HaveOccurred())
 	

--- a/precompile_process_test.go
+++ b/precompile_process_test.go
@@ -75,8 +75,14 @@ func testPrecompileProcess(t *testing.T, context spec.G, it spec.S) {
 			Expect(executions[0].Env).To(ContainElement("SECRET_KEY_BASE=dummy"))
 		})
 
+           context("when a user sets their own RAILS_ENV", func() {
+                it.Before(func() {
+                  Expect(os.Setenv("RAILS_ENV", "staging")).To(Succeed())
+                })
+                it.After(func() {
+                    Expect(os.Unsetenv("RAILS_ENV")).To(Succeed())
+                })
 		it("runs the bundle exec assets:precompile process while respecting RAILS_ENV", func() {
-			os.Setenv("RAILS_ENV", "staging")
 			err := precompileProcess.Execute(workingDir)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -85,6 +91,7 @@ func testPrecompileProcess(t *testing.T, context spec.G, it spec.S) {
 			Expect(executions[0].Env).To(ContainElement("RAILS_ENV=staging"))
 			Expect(executions[0].Env).To(ContainElement("SECRET_KEY_BASE=dummy"))
 		})
+	})
 
 		it("runs the bundle exec assets:precompile process while respecting SECRET_KEY_BASE", func() {
 			os.Setenv("SECRET_KEY_BASE", "dummy2")

--- a/precompile_process_test.go
+++ b/precompile_process_test.go
@@ -59,33 +59,33 @@ func testPrecompileProcess(t *testing.T, context spec.G, it spec.S) {
 			Expect(executions[0].Env).To(ContainElement("SECRET_KEY_BASE=dummy"))
 		})
 
-           context("when a user sets their own RAILS_ENV", func() {
-                it.Before(func() {
-                  Expect(os.Setenv("RAILS_ENV", "staging")).To(Succeed())
-                })
-                it.After(func() {
-                    Expect(os.Unsetenv("RAILS_ENV")).To(Succeed())
-                })
-		it("runs the bundle exec assets:precompile process while respecting RAILS_ENV", func() {
-			err := precompileProcess.Execute(workingDir)
-			Expect(err).NotTo(HaveOccurred())
+	        context("when a user sets their own RAILS_ENV", func() {
+			it.Before(func() {
+				Expect(os.Setenv("RAILS_ENV", "staging")).To(Succeed())
+			})
+			it.After(func() {
+				Expect(os.Unsetenv("RAILS_ENV")).To(Succeed())
+			})
+			it("runs the bundle exec assets:precompile process while respecting RAILS_ENV", func() {
+				err := precompileProcess.Execute(workingDir)
+				Expect(err).NotTo(HaveOccurred())
 
-			Expect(executions).To(HaveLen(1))
-			Expect(executions[0].Args).To(Equal([]string{"exec", "rails", "assets:precompile", "assets:clean"}))
-			Expect(executions[0].Env).To(ContainElement("RAILS_ENV=staging"))
-			Expect(executions[0].Env).To(ContainElement("SECRET_KEY_BASE=dummy"))
-		})
-	})
+				Expect(executions).To(HaveLen(1))
+				Expect(executions[0].Args).To(Equal([]string{"exec", "rails", "assets:precompile", "assets:clean"}))
+				Expect(executions[0].Env).To(ContainElement("RAILS_ENV=staging"))
+				Expect(executions[0].Env).To(ContainElement("SECRET_KEY_BASE=dummy"))
+			})
 
-		it("runs the bundle exec assets:precompile process while respecting SECRET_KEY_BASE", func() {
-			os.Setenv("SECRET_KEY_BASE", "dummy2")
-			err := precompileProcess.Execute(workingDir)
-			Expect(err).NotTo(HaveOccurred())
-
-			Expect(executions).To(HaveLen(1))
-			Expect(executions[0].Args).To(Equal([]string{"exec", "rails", "assets:precompile", "assets:clean"}))
-			Expect(executions[0].Env).To(ContainElement("RAILS_ENV=production"))
-			Expect(executions[0].Env).To(ContainElement("SECRET_KEY_BASE=dummy2"))
+			it("runs the bundle exec assets:precompile process while respecting SECRET_KEY_BASE", func() {
+				os.Setenv("SECRET_KEY_BASE", "dummy2")
+				err := precompileProcess.Execute(workingDir)
+				Expect(err).NotTo(HaveOccurred())
+	
+				Expect(executions).To(HaveLen(1))
+				Expect(executions[0].Args).To(Equal([]string{"exec", "rails", "assets:precompile", "assets:clean"}))
+				Expect(executions[0].Env).To(ContainElement("RAILS_ENV=production"))
+				Expect(executions[0].Env).To(ContainElement("SECRET_KEY_BASE=dummy2"))
+			})
 		})
 
 		context("failure cases", func() {

--- a/precompile_process_test.go
+++ b/precompile_process_test.go
@@ -25,11 +25,6 @@ func testPrecompileProcess(t *testing.T, context spec.G, it spec.S) {
 			executable *fakes.Executable
 
 			precompileProcess railsassets.PrecompileProcess
-
-			hasRailsEnv      bool
-			hasSecretKeyBase bool
-			railsEnv         string
-			secretKeyBase    string
 		)
 
 		it.Before(func() {
@@ -48,20 +43,9 @@ func testPrecompileProcess(t *testing.T, context spec.G, it spec.S) {
 			logger := scribe.NewEmitter(bytes.NewBuffer(nil))
 
 			precompileProcess = railsassets.NewPrecompileProcess(executable, logger)
-
-			railsEnv, hasRailsEnv = os.LookupEnv("RAILS_ENV")
-			secretKeyBase, hasSecretKeyBase = os.LookupEnv("SECRET_KEY_BASE")
 		})
 
 		it.After(func() {
-			if hasRailsEnv {
-				os.Setenv("RAILS_ENV", railsEnv)
-			}
-
-			if hasSecretKeyBase {
-				os.Setenv("SECRET_KEY_BASE", secretKeyBase)
-			}
-
 			Expect(os.RemoveAll(workingDir)).To(Succeed())
 		})
 

--- a/precompile_process_test.go
+++ b/precompile_process_test.go
@@ -25,6 +25,11 @@ func testPrecompileProcess(t *testing.T, context spec.G, it spec.S) {
 			executable *fakes.Executable
 
 			precompileProcess railsassets.PrecompileProcess
+
+			hasRailsEnv      bool
+			hasSecretKeyBase bool
+			railsEnv         string
+			secretKeyBase    string
 		)
 
 		it.Before(func() {
@@ -43,9 +48,20 @@ func testPrecompileProcess(t *testing.T, context spec.G, it spec.S) {
 			logger := scribe.NewEmitter(bytes.NewBuffer(nil))
 
 			precompileProcess = railsassets.NewPrecompileProcess(executable, logger)
+
+			railsEnv, hasRailsEnv = os.LookupEnv("RAILS_ENV")
+			secretKeyBase, hasSecretKeyBase = os.LookupEnv("SECRET_KEY_BASE")
 		})
 
 		it.After(func() {
+			if hasRailsEnv {
+				os.Setenv("RAILS_ENV", railsEnv)
+			}
+
+			if hasSecretKeyBase {
+				os.Setenv("SECRET_KEY_BASE", secretKeyBase)
+			}
+
 			Expect(os.RemoveAll(workingDir)).To(Succeed())
 		})
 
@@ -57,6 +73,28 @@ func testPrecompileProcess(t *testing.T, context spec.G, it spec.S) {
 			Expect(executions[0].Args).To(Equal([]string{"exec", "rails", "assets:precompile", "assets:clean"}))
 			Expect(executions[0].Env).To(ContainElement("RAILS_ENV=production"))
 			Expect(executions[0].Env).To(ContainElement("SECRET_KEY_BASE=dummy"))
+		})
+
+		it("runs the bundle exec assets:precompile process while respecting RAILS_ENV", func() {
+			os.Setenv("RAILS_ENV", "staging")
+			err := precompileProcess.Execute(workingDir)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(executions).To(HaveLen(1))
+			Expect(executions[0].Args).To(Equal([]string{"exec", "rails", "assets:precompile", "assets:clean"}))
+			Expect(executions[0].Env).To(ContainElement("RAILS_ENV=staging"))
+			Expect(executions[0].Env).To(ContainElement("SECRET_KEY_BASE=dummy"))
+		})
+
+		it("runs the bundle exec assets:precompile process while respecting SECRET_KEY_BASE", func() {
+			os.Setenv("SECRET_KEY_BASE", "dummy2")
+			err := precompileProcess.Execute(workingDir)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(executions).To(HaveLen(1))
+			Expect(executions[0].Args).To(Equal([]string{"exec", "rails", "assets:precompile", "assets:clean"}))
+			Expect(executions[0].Env).To(ContainElement("RAILS_ENV=production"))
+			Expect(executions[0].Env).To(ContainElement("SECRET_KEY_BASE=dummy2"))
 		})
 
 		context("failure cases", func() {


### PR DESCRIPTION
## Summary

This change allows users to set alternative values for RAILS_ENV and SECRET_KEY_BASE when precompiling assets.

Closes #200

## Use Cases

I want to compile my dependencies with `RAILS_ENV=staging` and I couldn't before.

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
