### PR TITLE
Revert "Add targets to buildpack.toml"

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -17,11 +17,3 @@ api = "0.7"
 
 [[stacks]]
   id = "*"
-
-[[targets.distros]]
-name = "ubuntu"
-version = "18.04"
-
-[[targets.distros]]
-name = "ubuntu"
-version = "22.04"


### PR DESCRIPTION
This reverts commit 70887dbde8bc49f1bc7bc4a134ef2ae5c6956590.

 - This change was made in error. We can re-evaluate introducing targets when we bump the buildpack API spec.
